### PR TITLE
Handle DEFLATE-compressed files and other UX improvements

### DIFF
--- a/taswira/taswira/app.py
+++ b/taswira/taswira/app.py
@@ -247,7 +247,7 @@ def get_app():
         y_margs = []
         for year, meta in data[title].items():
             x_marks.append(year)
-            y_margs.append(meta['metadata']['value'])
+            y_margs.append(meta['metadata']['indicator_value'])
         fig.add_trace(go.Scatter(x=x_marks, y=y_margs, mode='lines+markers'))
 
         unit = ''

--- a/taswira/taswira/scripts/ingestion.py
+++ b/taswira/taswira/scripts/ingestion.py
@@ -62,8 +62,8 @@ def ingest(rasterdir, db_results, outputdir):
             computed_metadata = driver.compute_metadata(
                 raster_path,
                 extra_metadata={
-                    'value': str(metadata[title][year]),
                     'colormap': config.get('palette').lower(),
+                    'indicator_value': str(metadata[title][year]),
                     'unit': unit.value[2]
                 })
             keys = (title, year)


### PR DESCRIPTION
## Description

Users will now be warned when they try to use the tool with anything other
than ZSTD-compressed COGs. They can however, still use the tool with such files by passing the `--allow-unoptimized` flag. Fixes #28

Also, now the UI will be automatically opened in the web browser.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually and using unit tests.

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [X] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->