### PR TITLE
Fix typo in find_units docstring #37

### DIFF
--- a/src/taswira/units.py
+++ b/src/taswira/units.py
@@ -20,7 +20,7 @@ class Units(Enum):
 
 
 def find_units(units_str):
-    """Finds the unit from that's represented by the provided string.
+    """Finds the unit that's represented by the provided string.
 
     Args:
         units_str: String containing valid unit.


### PR DESCRIPTION
## Description

Fixed the typo in the src/taswira/units.py find_units function's docstring. 

Fixes #37 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit-tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.